### PR TITLE
Add sdu time_of_arrival for RLC TM mode

### DIFF
--- a/lib/rlc/rlc_tx_tm_entity.cpp
+++ b/lib/rlc/rlc_tx_tm_entity.cpp
@@ -84,6 +84,7 @@ rlc_tx_tm_entity::rlc_tx_tm_entity(gnb_du_id_t                          du_id_,
 void rlc_tx_tm_entity::handle_sdu(byte_buffer sdu_buf, bool is_retx)
 {
   rlc_sdu sdu_;
+  sdu_.time_of_arrival = std::chrono::high_resolution_clock::now();
 
   sdu_.buf = std::move(sdu_buf);
 


### PR DESCRIPTION
There are Jbpf hooks to provide latencies for how long RLC takes to send SDUs.
For TM mode, there was an error whereby the SDU time-or-arrival was not being set.
